### PR TITLE
Craft 3.1.x support

### DIFF
--- a/src/controllers/LinkController.php
+++ b/src/controllers/LinkController.php
@@ -205,8 +205,16 @@ class LinkController extends Controller
                 return;
             }
         }
-        
-        if (!Craft::$app->getUser()->checkPermission($permissionName.':'.$asset->volumeId)) {
+
+        // choose $volumeId by Craft version
+        if (version_compare(Craft::$app->getInfo()->version, "3.1", "<")) {
+            // 3.0.x
+            $volumeId = $asset->volumeId;
+        } else {
+            //3.1.x
+            $volumeId = $asset->getVolume()->uid;
+        }
+        if (!Craft::$app->getUser()->checkPermission($permissionName.':'.$volumeId)) {
             throw new ForbiddenHttpException('User is not permitted to perform this action');
         }
     }


### PR DESCRIPTION
Hi, 
updated my Craft to 3.1.x and could not open protected files anymore.

This commit loads permissions by :uid for Craft 3.1.x

From Craft changelog: 
> System user permissions now reference things by their UIDs rather than IDs (e.g. **editEntries:UID** rather than **editEntries:ID**).



