### PR TITLE
fix renamed viewVolumes to viewAssets permission

### DIFF
--- a/src/controllers/LinkController.php
+++ b/src/controllers/LinkController.php
@@ -163,7 +163,7 @@ class LinkController extends Controller
 
         //if membership is not required, asset permissions can be ignored
         if (!empty($link['requireLogin']) || !empty($link['members']) || !empty($link['memberGroups'])) {
-            $this->_requirePermissionByAsset('viewVolume', $asset);
+            $this->_requirePermissionByAsset('viewAssets', $asset);
         }
         
         //update downloads counter


### PR DESCRIPTION
Adds to issue #15 and pull request #16.

In Craft 4 the `viewVolume` permission was renamed to `viewAssets`.
https://github.com/craftcms/cms/blob/4.4/CHANGELOG.md#changed-20